### PR TITLE
Fixed relative path matching issue in ConventionDependenciesPlugin

### DIFF
--- a/src/ConventionDependenciesPlugin.ts
+++ b/src/ConventionDependenciesPlugin.ts
@@ -36,7 +36,7 @@ export class ConventionDependenciesPlugin extends BaseIncludePlugin {
       if (/^async[!?]/.test(rawRequest)) {
         return;
       }
-      if (!minimatch(path.relative(root, file), this.glob, {dot: true})) {
+      if (!minimatch(path.resolve(root, file), this.glob, {dot: true})) {
         return;
       }
 


### PR DESCRIPTION
Fixed issue where minimatch would not match relative paths starting with `../` by feeding it resolved file paths. 
This caused issues in pnpm monorepos where Aurelia views of plugins were not included in the bundle because because they were wrongly disregarded.